### PR TITLE
Fix: send a message

### DIFF
--- a/Karma/Views/Posts/Details.cshtml
+++ b/Karma/Views/Posts/Details.cshtml
@@ -115,6 +115,14 @@
         if (text) {
             SendMessage(text);
         }
+        else {
+            Swal.fire({
+                title: 'Could not send a message!',
+                text: 'Your message is empty.',
+                icon: 'error',
+                confirmButtonColor: '#05718f'
+            });
+        }
     };
 
     function SendMessage(text) {


### PR DESCRIPTION
Previously there were no notifications if user tries to send an empty message. Now it alerts the user if his message is empty