### PR TITLE
Enhancement charity location

### DIFF
--- a/Karma/Controllers/CharitiesController.cs
+++ b/Karma/Controllers/CharitiesController.cs
@@ -83,20 +83,20 @@ namespace Karma.Controllers
 
         public async Task<List<Address>> GetCharityLocales(Charity charity)
         {
-            var addresses = new List<Address>();
-            var charityAddresses = GetCharityAddresses(charity).Result;
-            var serviceApiKey = _googleMaps.ServiceApiKey;
+            List<Address> addresses = new List<Address>();
+            List<CharityAddress> charityAddresses = GetCharityAddresses(charity).Result;
+            string serviceApiKey = _googleMaps.ServiceApiKey;
 
             if (serviceApiKey != null)
             {
                 ViewBag.ApiKey = serviceApiKey; 
-                var geocoder = new GoogleGeocoder(serviceApiKey);
+                GoogleGeocoder geocoder = new GoogleGeocoder(serviceApiKey);
 
-                foreach (var address in charityAddresses)
+                foreach (CharityAddress address in charityAddresses)
                 {
-                    var fullAddress = address.GetFullAddress();
-                    var googleAddress = await geocoder.GeocodeAsync(fullAddress);
-                    var first = googleAddress.FirstOrDefault();
+                    string fullAddress = address.GetFullAddress();
+                    IEnumerable<GoogleAddress> googleAddress = await geocoder.GeocodeAsync(fullAddress);
+                    GoogleAddress first = googleAddress.FirstOrDefault();
 
                     if(first != null)
                         addresses.Add(first);

--- a/Karma/Controllers/CharitiesController.cs
+++ b/Karma/Controllers/CharitiesController.cs
@@ -69,6 +69,13 @@ namespace Karma.Controllers
                 return NotFound();
             }
 
+            var charityAddresses = await _context.CharityAddress
+                .Where(m => m.CharityId == charity.Id)
+                .OrderBy(m => m.Country)
+                .ThenBy(m => m.City)
+                .ToListAsync();
+            charity.CharityAddresses = charityAddresses;
+
             return View(charity);
         }
 

--- a/Karma/Controllers/CharitiesController.cs
+++ b/Karma/Controllers/CharitiesController.cs
@@ -10,6 +10,9 @@ using Karma.Models;
 using System.IO;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
+using Geocoding;
+using Geocoding.Google;
+using Microsoft.Extensions.Configuration;
 
 namespace Karma.Controllers
 {
@@ -19,13 +22,16 @@ namespace Karma.Controllers
 
         private readonly IWebHostEnvironment _iWebHostEnv;
 
+        private readonly GoogleMaps _googleMaps;
+
         private List<Charity> _charities;
 
         // Passes an object of type IWebHostEnvironment that carries information about our host environment.
-        public CharitiesController(KarmaContext context, IWebHostEnvironment webHostEnvironment)
+        public CharitiesController(KarmaContext context, IWebHostEnvironment webHostEnvironment, GoogleMaps googleMaps)
         {
             _context = context;
             _iWebHostEnv = webHostEnvironment;
+            _googleMaps = googleMaps;
 
             _charities = GetCharityList().Result;
         }
@@ -69,14 +75,35 @@ namespace Karma.Controllers
                 return NotFound();
             }
 
-            var charityAddresses = await _context.CharityAddress
-                .Where(m => m.CharityId == charity.Id)
-                .OrderBy(m => m.Country)
-                .ThenBy(m => m.City)
-                .ToListAsync();
-            charity.CharityAddresses = charityAddresses;
+            var charityAddresses = GetCharityLocales(charity).Result;
+            ViewBag.CharityAddresses = charityAddresses;
 
             return View(charity);
+        }
+
+        public async Task<List<Address>> GetCharityLocales(Charity charity)
+        {
+            var addresses = new List<Address>();
+            var charityAddresses = GetCharityAddresses(charity).Result;
+            var serviceApiKey = _googleMaps.ServiceApiKey;
+
+            if (serviceApiKey != null)
+            {
+                ViewBag.ApiKey = serviceApiKey; 
+                var geocoder = new GoogleGeocoder(serviceApiKey);
+
+                foreach (var address in charityAddresses)
+                {
+                    var fullAddress = address.GetFullAddress();
+                    var googleAddress = await geocoder.GeocodeAsync(fullAddress);
+                    var first = googleAddress.FirstOrDefault();
+
+                    if(first != null)
+                        addresses.Add(first);
+                }
+            }
+
+            return addresses;
         }
 
         // GET: Charities/Create
@@ -241,6 +268,8 @@ namespace Karma.Controllers
         {
             var charityAddressesList = await _context.CharityAddress
                 .Where(x => x.CharityId == charity.Id)
+                .OrderBy(m => m.Country)
+                .ThenBy(m => m.City)
                 .ToListAsync();
 
             return charityAddressesList;

--- a/Karma/GoogleMaps.cs
+++ b/Karma/GoogleMaps.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Karma
+{
+    public class GoogleMaps
+    {
+        public string ServiceApiKey { get; set; }
+    }
+}

--- a/Karma/Karma.csproj
+++ b/Karma/Karma.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net5.0</TargetFramework>
     <CopyRefAssembliesToPublishDirectory>false</CopyRefAssembliesToPublishDirectory>
 	<PreserveCompilationContext>true</PreserveCompilationContext>
+	<UserSecretsId>d6c86dc7-62cc-4bbe-91ee-be393d536908</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>
@@ -22,6 +23,8 @@
     <PackageReference Include="bootstrap.sass" Version="5.1.2" />
     <PackageReference Include="FluentEmail.Razor" Version="3.0.0" />
     <PackageReference Include="FluentEmail.Smtp" Version="3.0.0" />
+    <PackageReference Include="Geocoding.Core" Version="4.0.1" />
+    <PackageReference Include="Geocoding.Google" Version="4.0.1" />
     <PackageReference Include="Localization.AspNetCore.TagHelpers" Version="0.6.0" />
     <PackageReference Include="Microsoft.AspNet.Identity.Core" Version="2.2.3" />
     <PackageReference Include="Microsoft.AspNet.Identity.Owin" Version="2.2.3" />

--- a/Karma/Models/Charity.cs
+++ b/Karma/Models/Charity.cs
@@ -24,7 +24,7 @@ namespace Karma.Models
         [MaxLength(120)]
         public string Description { get; set; }
         [NotMapped]
-        [Display(Name = "Item types")]
+        [Display(Name = "Charity addresses")]
         public List<CharityAddress> CharityAddresses { get; set; }
         [NotMapped]
         [Display(Name = "Item types")]

--- a/Karma/Models/CharityAddress.cs
+++ b/Karma/Models/CharityAddress.cs
@@ -43,8 +43,10 @@ namespace Karma.Models
         {
             var streetAndHouseNumber = string.Join(" ", this.Street, this.HouseNumber);
 
-            var fullAddress = string.Join(", ", this.Country, this.City, streetAndHouseNumber,
-                    (string.IsNullOrEmpty(this.PostCode) ? "" : this.PostCode));
+            var fullAddress = string.Join(", ", this.Country, this.City, streetAndHouseNumber);
+
+            if (!string.IsNullOrEmpty(this.PostCode))
+                fullAddress = string.Join(", ", fullAddress, this.PostCode);
 
             return fullAddress;
         }

--- a/Karma/Models/CharityAddress.cs
+++ b/Karma/Models/CharityAddress.cs
@@ -41,12 +41,12 @@ namespace Karma.Models
 
         public String GetFullAddress()
         {
-            var streetAndHouseNumber = string.Join(" ", this.Street, this.HouseNumber);
+            string streetAndHouseNumber = string.Join(" ", Street, HouseNumber);
 
-            var fullAddress = string.Join(", ", this.Country, this.City, streetAndHouseNumber);
+            string fullAddress = string.Join(", ", Country, City, streetAndHouseNumber);
 
-            if (!string.IsNullOrEmpty(this.PostCode))
-                fullAddress = string.Join(", ", fullAddress, this.PostCode);
+            if (!string.IsNullOrEmpty(PostCode))
+                fullAddress = string.Join(", ", fullAddress, PostCode);
 
             return fullAddress;
         }

--- a/Karma/Models/CharityAddress.cs
+++ b/Karma/Models/CharityAddress.cs
@@ -38,5 +38,15 @@ namespace Karma.Models
         {
             CharityId = charityId;
         }
+
+        public String GetFullAddress()
+        {
+            var streetAndHouseNumber = string.Join(" ", this.Street, this.HouseNumber);
+
+            var fullAddress = string.Join(", ", this.Country, this.City, streetAndHouseNumber,
+                    (string.IsNullOrEmpty(this.PostCode) ? "" : this.PostCode));
+
+            return fullAddress;
+        }
     }
 }

--- a/Karma/Startup.cs
+++ b/Karma/Startup.cs
@@ -58,9 +58,7 @@ namespace Karma
                     options.UseSqlite(Configuration.GetConnectionString("DefaultConnection")));
 
             // Adding singleton for Google Maps API
-            var maps = new GoogleMaps();
-            maps.ServiceApiKey = Configuration.GetValue<string>("GoogleMaps:ServiceApiKey");
-            services.AddSingleton<GoogleMaps>(maps);
+            services.AddSingleton<GoogleMaps>(ConfigureGoogleMaps());
 
             // Adding identity
             services.AddIdentity<Karma.Models.User, IdentityRole>()
@@ -139,6 +137,14 @@ namespace Karma
             System.IO.Directory.CreateDirectory(Path.Combine(env.WebRootPath, Karma.Models.Post.ImagesDirName));
             System.IO.Directory.CreateDirectory(Path.Combine(env.WebRootPath, Karma.Models.Advert.ImagesDirName));
             System.IO.Directory.CreateDirectory(Path.Combine(env.WebRootPath, Karma.Models.Charity.ImagesDirName));
+        }
+
+        private GoogleMaps ConfigureGoogleMaps()
+        {
+            GoogleMaps maps = new GoogleMaps();
+            maps.ServiceApiKey = Configuration.GetValue<string>("GoogleMaps:ServiceApiKey");
+
+            return maps;
         }
     }
 }

--- a/Karma/Startup.cs
+++ b/Karma/Startup.cs
@@ -57,6 +57,11 @@ namespace Karma
             services.AddDbContext<KarmaContext>(options =>
                     options.UseSqlite(Configuration.GetConnectionString("DefaultConnection")));
 
+            // Adding singleton for Google Maps API
+            var maps = new GoogleMaps();
+            maps.ServiceApiKey = Configuration.GetValue<string>("GoogleMaps:ServiceApiKey");
+            services.AddSingleton<GoogleMaps>(maps);
+
             // Adding identity
             services.AddIdentity<Karma.Models.User, IdentityRole>()
                 .AddDefaultUI()

--- a/Karma/Views/Charities/Details.cshtml
+++ b/Karma/Views/Charities/Details.cshtml
@@ -1,16 +1,28 @@
-﻿@model Karma.Models.Charity
+﻿@using Geocoding;
+
+@model Karma.Models.Charity
 
 @{
     ViewData["Title"] = "Details";
     var charityItemTypes = Model.GetItemTypes();
+    var charityAddresses = (List<Address>)ViewBag.CharityAddresses;
+
+    var lat = charityAddresses.First().Coordinates.Latitude;
+    var lng = charityAddresses.First().Coordinates.Longitude;
+
+    var googleApi = "https://maps.googleapis.com/maps/api/js?key=" + (string)ViewBag.ApiKey;
 }
 
+<head>
+    <script src=@googleApi></script>
+</head>
 
 <h1>@Model.Name</h1>
 
+<body onload="loadMap(@lat, @lng)">
 <div class="container">
     <div class="row align-content-between">
-        <div class="col col-12 col-sm-6 col-md-6 col-lg-6">
+        <div class="col col-12 col-sm-12 col-md-12 col-lg-5 mb-4">
             <h5>
                 @if (charityItemTypes.Any())
                 {
@@ -24,30 +36,31 @@
             @if (Model.ImagePath != null && Model.ImagePath != "")
             {
                 <img src="/@Charity.ImagesDirName/@Model.ImagePath" asp-append-version="true"
-                        alt="Item image" class="img-fluid" style="max-width:500px;" />
+                     alt="Item image" class="img-fluid" style="max-width:400px;" />
                 <br />
             }
         </div>
-        <div class="col col-12 col-sm-5 col-md-5 col-lg-5">
+        <div class="col col-12 col-sm-12 col-md-12 col-lg-6">
             @if (Model.CharityAddresses.Any())
             {
-                <h5>Where can you find the charity?</h5>
-                <hr />
+                <h5 class="mb-4">Where can you find the charity?</h5>
                 <ul class="list-group">
-                    @foreach (var address in Model.CharityAddresses)
+                    @foreach (var address in charityAddresses)
                     {
-                        <li class="list-group-item">@address.Country, @address.City, @address.Street @address.HouseNumber</li>
+                        <li class="list-group-item" lat=@address.Coordinates.Latitude 
+                            lng="@address.Coordinates.Longitude">@address.FormattedAddress</li>
                     }
                 </ul>
+                <div id="map" class="mt-4" style="width:500px; height:400px;"></div>
             }
             else
             {
-                <h5>We're sorry, the charity hasn't provided their location</h5>
-                <hr />
+                <h5>We're sorry, the charity hasn't provided their location</h5><hr />
             }
         </div>
     </div>
 </div>
+</body>
 
 <script>
     $(function () {
@@ -56,8 +69,27 @@
             $that = $(this);
             $that.parent().find('li').removeClass('active');
             $that.addClass('active');
-        })
-    })
 
+            var lat = this.attributes.lat.value;
+            var lng = this.attributes.lng.value;
+            loadMap(lat, lng);
+        })
+    });
+
+    function loadMap(lat, lng) {
+
+        var mapOptions = {
+            center: new google.maps.LatLng(lat, lng),
+            zoom: 10
+        }
+
+        var map = new google.maps.Map(document.getElementById("map"), mapOptions);
+
+        var marker = new google.maps.Marker({
+            position: new google.maps.LatLng(lat, lng),
+            map: map,
+        });
+    }
 
 </script>
+

--- a/Karma/Views/Charities/Details.cshtml
+++ b/Karma/Views/Charities/Details.cshtml
@@ -6,30 +6,58 @@
 }
 
 
-<h1>@Model.Name
-    <span class="badge @(Model.ReviewState == Enums.ReviewState.Approved? "badge-success" : "badge-secondary") mb-3">
-    @Html.DisplayFor(model => model.ReviewState)</span>
-</h1>
+<h1>@Model.Name</h1>
 
-<div>
-    <h5>
-        @if (charityItemTypes.Any())
-        {
-            foreach(var itemType in Model.CharityItemTypes)
+<div class="container">
+    <div class="row align-content-between">
+        <div class="col col-12 col-sm-6 col-md-6 col-lg-6">
+            <h5>
+                @if (charityItemTypes.Any())
+                {
+                    foreach (var itemType in Model.CharityItemTypes)
+                    {
+                        <span class="badge badge-pill badge-info">@itemType.ItemType.Name</span>
+                    }
+                }
+            </h5>
+            <hr />
+            @if (Model.ImagePath != null && Model.ImagePath != "")
             {
-                <span class="badge badge-pill badge-info">@itemType.ItemType.Name</span>
+                <img src="/@Charity.ImagesDirName/@Model.ImagePath" asp-append-version="true"
+                        alt="Item image" class="img-fluid" style="max-width:500px;" />
+                <br />
             }
-        }
-    </h5>
-    <hr />
-    @if (Model.ImagePath != null && Model.ImagePath != "")
-    {
-        <img src="/@Charity.ImagesDirName/@Model.ImagePath" asp-append-version="true"
-             alt="Item image" class="img-fluid" style="max-width:400px;" />
-        <br />
-    }
+        </div>
+        <div class="col col-12 col-sm-5 col-md-5 col-lg-5">
+            @if (Model.CharityAddresses.Any())
+            {
+                <h5>Where can you find the charity?</h5>
+                <hr />
+                <ul class="list-group">
+                    @foreach (var address in Model.CharityAddresses)
+                    {
+                        <li class="list-group-item">@address.Country, @address.City, @address.Street @address.HouseNumber</li>
+                    }
+                </ul>
+            }
+            else
+            {
+                <h5>We're sorry, the charity hasn't provided their location</h5>
+                <hr />
+            }
+        </div>
+    </div>
 </div>
-<hr />
-<div>
-    Posted at @Html.DisplayFor(model => model.DateCreated)
-</div>
+
+<script>
+    $(function () {
+        $('.list-group li').click(function (e) {
+            e.preventDefault();
+            $that = $(this);
+            $that.parent().find('li').removeClass('active');
+            $that.addClass('active');
+        })
+    })
+
+
+</script>

--- a/Karma/Views/Charities/Details.cshtml
+++ b/Karma/Views/Charities/Details.cshtml
@@ -7,10 +7,15 @@
     var charityItemTypes = Model.GetItemTypes();
     var charityAddresses = (List<Address>)ViewBag.CharityAddresses;
 
-    var lat = charityAddresses.First().Coordinates.Latitude;
-    var lng = charityAddresses.First().Coordinates.Longitude;
+    double lat = 0;
+    double lng = 0;
+    if (charityAddresses.Any())
+    {
+        lat = charityAddresses.First().Coordinates.Latitude;
+        lng = charityAddresses.First().Coordinates.Longitude;
+    }
 
-    var googleApi = "https://maps.googleapis.com/maps/api/js?key=" + (string)ViewBag.ApiKey;
+    var googleApi = "https://maps.googleapis.com/maps/api/js?key=" + (string) ViewBag.ApiKey;
 }
 
 <head>
@@ -20,46 +25,56 @@
 <h1>@Model.Name</h1>
 
 <body onload="loadMap(@lat, @lng)">
-<div class="container">
-    <div class="row align-content-between">
-        <div class="col col-12 col-sm-12 col-md-12 col-lg-5 mb-4">
-            <h5>
-                @if (charityItemTypes.Any())
+    <div class="container">
+        <div class="row align-content-between">
+            <div class="col col-12 col-sm-12 col-md-12 col-lg-5 mb-4">
+                <h5>
+                    @if (charityItemTypes.Any())
+                    {
+                        foreach (var itemType in Model.CharityItemTypes)
+                        {
+                            <span class="badge badge-pill badge-info">@itemType.ItemType.Name</span>
+                        }
+                    }
+                </h5>
+                <hr />
+                @if (Model.ImagePath != null && Model.ImagePath != "")
                 {
-                    foreach (var itemType in Model.CharityItemTypes)
-                    {
-                        <span class="badge badge-pill badge-info">@itemType.ItemType.Name</span>
-                    }
+                    <img src="/@Charity.ImagesDirName/@Model.ImagePath" asp-append-version="true"
+                         alt="Item image" class="img-fluid" style="max-width:400px;" />
+                    <br />
                 }
-            </h5>
-            <hr />
-            @if (Model.ImagePath != null && Model.ImagePath != "")
-            {
-                <img src="/@Charity.ImagesDirName/@Model.ImagePath" asp-append-version="true"
-                     alt="Item image" class="img-fluid" style="max-width:400px;" />
-                <br />
-            }
-        </div>
-        <div class="col col-12 col-sm-12 col-md-12 col-lg-6">
-            @if (Model.CharityAddresses.Any())
-            {
-                <h5 class="mb-4">Where can you find the charity?</h5>
-                <ul class="list-group">
-                    @foreach (var address in charityAddresses)
-                    {
-                        <li class="list-group-item" lat=@address.Coordinates.Latitude 
-                            lng="@address.Coordinates.Longitude">@address.FormattedAddress</li>
-                    }
-                </ul>
-                <div id="map" class="mt-4" style="width:500px; height:400px;"></div>
-            }
-            else
-            {
-                <h5>We're sorry, the charity hasn't provided their location</h5><hr />
-            }
+            </div>
+            <div class="col col-12 col-sm-12 col-md-12 col-lg-6">
+                @if (charityAddresses.Any())
+                {
+                    <h5 class="mb-4">Where can you find the charity?</h5>
+                    <ul class="list-group">
+                        @foreach (var address in charityAddresses)
+                        {
+                            <li class="list-group-item" lat=@address.Coordinates.Latitude
+                                lng="@address.Coordinates.Longitude">@address.FormattedAddress</li>
+                            }
+                    </ul>
+                    <div id="map" class="mt-4" style="width:500px; height:400px;"></div>
+                }
+                else if (Model.CharityAddresses.Any())
+                {
+                    <h5 class="mb-4">Where can you find the charity?</h5>
+                    <ul class="list-group">
+                        @foreach (var address in Model.CharityAddresses)
+                        {
+                            <li class="list-group-item">@address.GetFullAddress()</li>
+                        }
+                    </ul>
+                }
+                else
+                {
+                    <h5>We're sorry, the charity hasn't provided their location</h5><hr />
+                }
+            </div>
         </div>
     </div>
-</div>
 </body>
 
 <script>
@@ -77,18 +92,19 @@
     });
 
     function loadMap(lat, lng) {
+        if (lat != 0 && lng != 0) {
+            var mapOptions = {
+                center: new google.maps.LatLng(lat, lng),
+                zoom: 10
+            }
 
-        var mapOptions = {
-            center: new google.maps.LatLng(lat, lng),
-            zoom: 10
+            var map = new google.maps.Map(document.getElementById("map"), mapOptions);
+
+            var marker = new google.maps.Marker({
+                position: new google.maps.LatLng(lat, lng),
+                map: map,
+            });
         }
-
-        var map = new google.maps.Map(document.getElementById("map"), mapOptions);
-
-        var marker = new google.maps.Marker({
-            position: new google.maps.LatLng(lat, lng),
-            map: map,
-        });
     }
 
 </script>

--- a/Karma/Views/Charities/DetailsForCharityManager.cshtml
+++ b/Karma/Views/Charities/DetailsForCharityManager.cshtml
@@ -1,0 +1,37 @@
+﻿@model Karma.Models.Charity
+
+@{
+    ViewData["Title"] = "Details";
+    var charityItemTypes = Model.GetItemTypes();
+}
+
+
+<h1>
+    @Model.Name
+<span class="badge @(Model.ReviewState == Enums.ReviewState.Approved? "badge-success" : "badge-secondary") mb-3">
+    @Html.DisplayFor(model => model.ReviewState)
+</span>
+</h1>
+
+<div>
+    <h5>
+        @if (charityItemTypes.Any())
+        {
+            foreach (var itemType in Model.CharityItemTypes)
+            {
+                <span class="badge badge-pill badge-info">@itemType.ItemType.Name</span>
+            }
+        }
+    </h5>
+    <hr />
+    @if (Model.ImagePath != null && Model.ImagePath != "")
+    {
+        <img src="/@Charity.ImagesDirName/@Model.ImagePath" asp-append-version="true"
+             alt="Item image" class="img-fluid" style="max-width:400px;" />
+        <br />
+    }
+</div>
+<hr />
+<div>
+    Posted at @Html.DisplayFor(model => model.DateCreated)
+</div>

--- a/Karma/Views/Charities/Edit.cshtml
+++ b/Karma/Views/Charities/Edit.cshtml
@@ -33,7 +33,7 @@
         </form>
     </div>
     <div class="col-md-6">
-        <partial name="~/Views/Charities/Details.cshtml" for="@Model" />
+        <partial name="~/Views/Charities/DetailsForCharityManager.cshtml" for="@Model" />
     </div>
 
 </div>

--- a/Karma/Views/Charities/FilteredCharities.cshtml
+++ b/Karma/Views/Charities/FilteredCharities.cshtml
@@ -27,7 +27,7 @@ else if (ViewBag.ItemType != null)
                     <div class="card-body">
                         <h5 class="card-title">@Html.DisplayFor(m => item.Name)</h5>
                         <p class="card-text">@Html.DisplayFor(model => item.Description)</p>
-                        <a asp-action="Details" asp-route-id="@item.Id" class="btn btn-primary">@Html.DisplayFor(m => item.Name)</a>
+                        <a asp-action="Details" asp-route-id="@item.Id" class="btn btn-primary">View details</a>
                     </div>
                 </div>
             </div>

--- a/Karma/Views/Charities/FilteredCharities.cshtml
+++ b/Karma/Views/Charities/FilteredCharities.cshtml
@@ -21,7 +21,8 @@ else if (ViewBag.ItemType != null)
                 <div class="card h-100">
                     @if (item.ImagePath != null && item.ImagePath != "")
                     {
-                        <img class="card-img-top ratio ratio-4x3" src="/@Charity.ImagesDirName/@item.ImagePath" asp-append-version="true" alt="">
+                        <img class="card-img-top ratio ratio-4x3" src="/@Charity.ImagesDirName/@item.ImagePath" asp-append-version="true" alt="" 
+                             style="max-height:300px; object-fit: cover;">
                     }
                     <div class="card-body">
                         <h5 class="card-title">@Html.DisplayFor(m => item.Name)</h5>


### PR DESCRIPTION
Made charity addresses viewable. You can also select the address and view the location on the map.
You have to use the API key to see the map (without it there will just be no map shown). 

:arrow_down: For more information on how to set up, see down below. 

![Screenshot 2021-12-04 at 12 43 03](https://user-images.githubusercontent.com/73688133/144707263-d9cee598-944d-4fbc-a2f5-53f775679091.png)

### Steps to do before reviewing:
1. `update-database`, like always
2. Go to `Project` > `Manage user secrets`, this will create a `secrets.json` file. Paste the API key there. Please contact me to get the API key.
3. You can change the addresses in `CharityAddresses` table to more accurate addresses to test the legitimacy of the map.

![Screenshot 2021-12-04 at 12 01 07](https://user-images.githubusercontent.com/73688133/144707175-0bdd5d69-f092-4234-a617-87279613bb80.png)

Once you will set up the API key you will never have to do that again.

### The logic behind this:
- The longitude and latitude are counted for the given address and in that way the location can be shown on the map.
- If the address is inaccurate, the location that is nearest by is shown on the map.

### Other changes made:
- Separated the charity details used in the CharityManager and details shown in Charities' search. Now there are 2 views: `Details.cshtml` and `DetailsForCharityManager.cshtml`

Note: first 2 commits are from my last PR.